### PR TITLE
Reduced transparency on diff colors

### DIFF
--- a/themes/doom-one-color-theme.json
+++ b/themes/doom-one-color-theme.json
@@ -61,7 +61,9 @@
         "terminal.ansiMagenta": "#c678dd",
         "terminal.ansiRed": "#ff6c6b",
         "terminal.ansiWhite": "#bbc2cf",
-        "terminal.ansiYellow": "#ecbe7b"
+        "terminal.ansiYellow": "#ecbe7b",
+        "diffEditor.insertedTextBackground": "#9ccc2d0d",
+        "diffEditor.removedTextBackground": "#ff00001a"
     },
     "tokenColors": [
         {


### PR DESCRIPTION
Before this change comments in the diff editor were very hard to read (and in the case of additions in diffs, unreadable):

Example (Before PR):
![Screen Shot 2022-09-26 at 12 52 41 PM](https://user-images.githubusercontent.com/86365960/192336078-e1889b96-6bd8-4f51-bddf-807dec1f861d.png)
![Screen Shot 2022-09-26 at 12 53 24 PM](https://user-images.githubusercontent.com/86365960/192336095-336877bc-75ad-4338-8f86-f8b3e7633087.png)

This PR reduces the transparency of the default diff editor colors so that comments are slightly more readable:

![Screen Shot 2022-09-26 at 12 52 53 PM](https://user-images.githubusercontent.com/86365960/192336192-0a0cb75c-1682-46ea-bc0c-d5a8094cbfca.png)
![Screen Shot 2022-09-26 at 12 53 15 PM](https://user-images.githubusercontent.com/86365960/192336206-44f7a68b-f59f-434f-9954-6fa46cb309b9.png)
